### PR TITLE
PHP 8.4 Warnings

### DIFF
--- a/src/Oauth/Signature/EncodesUrl.php
+++ b/src/Oauth/Signature/EncodesUrl.php
@@ -55,7 +55,7 @@ trait EncodesUrl
         return $normalizedArray;
     }
 
-    protected function queryStringFromData(array $data, array $queryParams = null, string $prevKey = ''): string
+    protected function queryStringFromData(array $data, ?array $queryParams = null, string $prevKey = ''): string
     {
         if ($initial = (null === $queryParams)) {
             $queryParams = [];


### PR DESCRIPTION
This fixes the PHP 8.4 warning:

```
Error: During class fetch: Uncaught Whoops\Exception\ErrorException: NetsuiteRestApi\Oauth\Signature\EncodesUrl::queryStringFromData(): Implicitly marking parameter $queryParams as nullable is deprecated, the explicit nullable type must be used
```